### PR TITLE
Correct includes value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=
 category=Other
 architectures=sam,esp8266
 url=https://github.com/Wolkabout/WolkConnect-Arduino
-includes=src/WolkConn.h,src/MQTTClient.h
+includes=WolkConn.h,MQTTClient.h


### PR DESCRIPTION
The `includes` field in library.properties is used to specify which `#include` directives should be added to the sketch via **Sketch > Include Library > WolkConnect**. The previous value caused compilation to fail:
```
error: src/WolkConn.h: No such file or directory

 #include <src/WolkConn.h>
```
Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format